### PR TITLE
Feature/update trust rel policy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: komiser
 description: Komiser Helm Chart
 type: application
-version: 2.8.1
-appVersion: 2.8.1
+version: 2.9.0
+appVersion: 2.9.0
 maintainers:
     - name: Mohamed Labouardy
       email: mohamed@oraculi.io

--- a/docs/create-service-account-iam-policy-and-role.md
+++ b/docs/create-service-account-iam-policy-and-role.md
@@ -30,7 +30,7 @@
          "Condition": {
            "StringEquals": {
              "${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
-             "${OIDC_PROVIDER}:sub": "system:serviceaccount:default:komiser"
+             "${OIDC_PROVIDER}:sub": "system:serviceaccount:${NAMESPACE}:komiser"
            }
          }
        }
@@ -39,6 +39,8 @@
    EOF
    echo "${TRUST_RELATIONSHIP}" > trust.json
    ```
+
+`NOTE: Make sure to substitute ${NAMESPACE} for the namespace you will deploy the helm chart in. If deployed in any other namespace, you will see sts:AssumeRoleWithWebIdentity failure messages in the pod logs.`
 
 1. Run the modified code block from the previous step to create a file named *`trust.json`*\.
 

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   name: komiser
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::602887012891:role/AWSEKSKomiserRole
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   name: komiser
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+    eks.amazonaws.com/role-arn: arn:aws:iam::602887012891:role/AWSEKSKomiserRole


### PR DESCRIPTION
Update the trust relationship policy to make sure we don't hardcode the namespace, allowing users to change the namespace their serviceAccount lives in.  