### PR TITLE
Tech 889/add-to-helmignore-file

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -22,3 +22,5 @@
 .vscode
 # OWNERS file for Kubernetes
 OWNERS
+docs/
+images/ 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: komiser
 description: Komiser Helm Chart
 type: application
-version: 3.0.1
-appVersion: 3.0.1
+version: 3.0.2
+appVersion: 3.0.2
 maintainers:
     - name: Mohamed Labouardy
       email: mohamed@tailwarden.com

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tailwarden/komiser
-  tag: 3.0.1
+  tag: 3.0.2
   pullPolicy: IfNotPresent
 
 aws:


### PR DESCRIPTION
- Added `docs/` and `images/` to the `.helmignore` file since they were blocking the correct deployment of the helm chart.
- Updated Komiser version to ---> 3.0.2 